### PR TITLE
fix: high anisotropy causes defects

### DIFF
--- a/cpp/edt.hpp
+++ b/cpp/edt.hpp
@@ -15,10 +15,8 @@
 
 #include <cmath>
 #include <cstdint>
-#include <stdio.h>
-
-#include <string.h>
 #include <algorithm>
+#include <limits>
 
 #ifndef EDT_H
 #define EDT_H
@@ -41,14 +39,14 @@ const int VERSION_BUGFIX = 0;
 inline void tofinite(float *f, const size_t voxels) {
   for (size_t i = 0; i < voxels; i++) {
     if (f[i] == INFINITY) {
-      f[i] = 1e10;
+      f[i] = std::numeric_limits<float>::max() - 1;
     }
   }
 }
 
 inline void toinfinite(float *f, const size_t voxels) {
   for (size_t i = 0; i < voxels; i++) {
-    if (f[i] >= 1e10) {
+    if (f[i] >= std::numeric_limits<float>::max() - 1) {
       f[i] = INFINITY;
     }
   }
@@ -71,7 +69,7 @@ inline void toinfinite(float *f, const size_t voxels) {
  */
 template <typename T>
 void squared_edt_1d_multi_seg(
-    T* __restrict__ segids, float * __restrict__ d, const int n, 
+    T* segids, float *d, const int n, 
     const int stride, const float anistropy,
     const bool black_border=false
   ) {

--- a/python/edt.hpp
+++ b/python/edt.hpp
@@ -15,9 +15,6 @@
 
 #include <cmath>
 #include <cstdint>
-#include <stdio.h>
-
-#include <string.h>
 #include <algorithm>
 
 #ifndef EDT_H

--- a/python/edt.hpp
+++ b/python/edt.hpp
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <cstdint>
 #include <algorithm>
+#include <limits>
 
 #ifndef EDT_H
 #define EDT_H
@@ -38,14 +39,14 @@ const int VERSION_BUGFIX = 0;
 inline void tofinite(float *f, const size_t voxels) {
   for (size_t i = 0; i < voxels; i++) {
     if (f[i] == INFINITY) {
-      f[i] = 1e10;
+      f[i] = std::numeric_limits<float>::max() - 1;
     }
   }
 }
 
 inline void toinfinite(float *f, const size_t voxels) {
   for (size_t i = 0; i < voxels; i++) {
-    if (f[i] >= 1e10) {
+    if (f[i] >= std::numeric_limits<float>::max() - 1) {
       f[i] = INFINITY;
     }
   }

--- a/python/test.py
+++ b/python/test.py
@@ -697,6 +697,31 @@ def test_3d_lopsided():
     print(size)
     assert np.all(cres == fres)
 
+def test_3d_high_anisotropy():
+  shape = (256, 256, 256)
+  anisotropy = (1000000, 1200000, 40)
+
+  labels = np.ones( shape, dtype=np.uint8)
+  labels[0, 0, 0] = 0
+  labels[-1, -1, -1] = 0
+
+  resedt = edt.edt(labels, anisotropy=anisotropy, black_border=False)
+
+  mx = np.max(resedt)
+  assert np.isfinite(mx)
+  assert mx <= (1e6 * 256) ** 2 + (1e6 * 256) ** 2 + (666 * 256) ** 2
+
+  resscipy = ndimage.distance_transform_edt(labels, sampling=anisotropy)
+  resscipy[ resscipy == 0 ] = 1
+  resedt[ resedt == 0 ] = 1
+  ratio = np.abs(resscipy / resedt)
+  assert np.all(ratio < 1.000001) and np.all(ratio > 0.999999)
+
+def test_all_inf():
+  shape = (128, 128, 128)
+  labels = np.ones( shape, dtype=np.uint8)
+  res = edt.edt(labels, black_border=False, anisotropy=(1,1,1))
+  assert np.all(res == np.inf)
 
 def test_numpy_anisotropy():
   labels = np.zeros(shape=(128, 128, 128), dtype=np.uint32)


### PR DESCRIPTION
The hack for dealing with infinities set the threshold way too low. We can set it to near the top of the floating point range.