### PR TITLE
fix: license configuration in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,8 @@ description_file = README.md
 author = William Silversmith
 author_email = ws9@princeton.edu
 home_page = https://github.com/seung-lab/euclidean-distance-transform-3d/
-license_file = LICENSE
-licenses = LGPL-3.0-or-later
+license_files = LICENSE
+license = LGPL-3.0-or-later
 classifier =
     Intended Audience :: Developers
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
According to https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-license, the keyword is `license`, not `licenses`. Also, `license_file` is deprecated in favor of `license_files`.